### PR TITLE
[AutoPR - Security] Patch vim for CVE-2026-55892 [MEDIUM]

### DIFF
--- a/base/comps/vim/CVE-2026-55892.patch
+++ b/base/comps/vim/CVE-2026-55892.patch
@@ -1,0 +1,94 @@
+From bd87bdc09adba01e6124165becc8fa3cf3e7cec1 Mon Sep 17 00:00:00 2001
+From: Yasuhiro Matsumoto <mattn.jp@gmail.com>
+Date: Tue, 16 Jun 2026 20:32:21 +0000
+Subject: [PATCH] patch 9.2.0662: [security] Stack out-of-bounds write in
+ dump_prefixes()
+
+Problem:  [security]: a crafted spell file with a self-referential
+          BY_INDEX node in the prefix tree can drive dump_prefixes()
+          past the end of its MAXWLEN-sized depth arrays on :spelldump
+          (cipher-creator)
+Solution: only descend while depth < MAXWLEN - 1, as the sibling trie
+          walkers already do (Yasuhiro Matsumoto)
+
+Github Security Advisory:
+https://github.com/vim/vim/security/advisories/GHSA-qm9w-fmpj-879h
+
+Supported by AI
+
+Signed-off-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>
+Signed-off-by: Christian Brabandt <cb@256bit.org>
+
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/vim/vim/commit/8325b193bba5f01e7a7d8241f.patch
+---
+ src/spell.c                |  2 +-
+ src/testdir/test_spell.vim | 27 +++++++++++++++++++++++++++
+ src/version.c              |  2 ++
+ 3 files changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/src/spell.c b/src/spell.c
+index d06a6b8..97a6051 100644
+--- a/src/spell.c
++++ b/src/spell.c
+@@ -4326,7 +4326,7 @@ dump_prefixes(
+ 			}
+ 		    }
+ 		}
+-		else
++		else if (depth < MAXWLEN - 1)
+ 		{
+ 		    // Normal char, go one level deeper.
+ 		    prefix[depth++] = c;
+diff --git a/src/testdir/test_spell.vim b/src/testdir/test_spell.vim
+index 170ea57..2a3f0e3 100644
+--- a/src/testdir/test_spell.vim
++++ b/src/testdir/test_spell.vim
+@@ -1567,4 +1567,31 @@ let g:test_data_aff_sal = [
+       \"SAL Z                    S",
+       \ ]
+ 
++" A crafted .spl with a self-referential BY_INDEX node in the PREFIXTREE drove
++" dump_prefixes() past its MAXWLEN-sized depth arrays (stack out-of-bounds
++" write).  The tree parses cleanly (shared refs aren't recursed); the walk
++" happens on :spelldump.  Reaching the assert means no OOB.  Same class as the
++" tree_count_words() fix (9.2.0653).
++func Test_spelldump_prefixtree_overflow()
++  CheckUnix
++  call mkdir('Xrtp/spell', 'pR')
++  " VIMspell + v50, SN_PREFCOND(prefixcnt=1), SN_END,
++  " LWORDTREE word "a" with affixID=1 (so dump_prefixes runs),
++  " empty KWORDTREE, PREFIXTREE child BY_INDEX -> nodeidx 0 (self-cycle), 'A'
++  let spl = eval('0z56494D7370656C6C32030000000003000100FF00000004'
++        \ .. '0161010220010000000000000002010100000041')
++  call writefile(spl, 'Xrtp/spell/xx.utf-8.spl', 'b')
++
++  new
++  set runtimepath+=./Xrtp
++  set spelllang=xx
++  set spell
++  spelldump
++  call assert_true(line('$') > 1)
++
++  set spell& spelllang& runtimepath&
++  bwipe!
++  bwipe!
++endfunc
++
+ " vim: shiftwidth=2 sts=2 expandtab
+diff --git a/src/version.c b/src/version.c
+index 963161d..0cd4da8 100644
+--- a/src/version.c
++++ b/src/version.c
+@@ -734,6 +734,8 @@ static char *(features[]) =
+ 
+ static int included_patches[] =
+ {   /* Add new patch number below this line */
++/**/
++    662,
+ /**/
+     2146,
+ /**/
+-- 
+2.45.4
+

--- a/base/comps/vim/vim.comp.toml
+++ b/base/comps/vim/vim.comp.toml
@@ -2,4 +2,34 @@
 # the gpm SRPM entirely to sdk. vim.spec uses bcond gating for GPM
 # (default ON when fedora is set); flip it off via build.without.
 [components.vim]
+release = { calculation = "manual" }
 build.without = ["gpm"]
+
+[[components.vim.overlays]]
+description = "Fix CVE-2026-55892 — https://github.com/vim/vim/commit/8325b193bba5f01e7a7d8241f"
+type = "patch-add"
+source = "CVE-2026-55892.patch"
+
+[[components.vim.overlays]]
+description = "Apply CVE-2026-55892 patch (CVE-2026-55892.patch)"
+type = "spec-append-lines"
+section = "%prep"
+lines = [
+    "%patch -P10001 -p1",
+]
+
+[[components.vim.overlays]]
+description = "Bump release for CVE-2026-55892"
+type = "spec-set-tag"
+tag = "Release"
+value = "5%{?dist}"
+
+[[components.vim.overlays]]
+description = "Add changelog entry for CVE-2026-55892"
+type = "spec-prepend-lines"
+section = "%changelog"
+lines = [
+    "* Sat Jul 04 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2:9.1.2146-5",
+    "- Patch for CVE-2026-55892",
+    "",
+]

--- a/locks/vim.lock
+++ b/locks/vim.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = 'f3e923a221a21ce1bc9608e57024789ae7b9e674'
 upstream-commit = 'f3e923a221a21ce1bc9608e57024789ae7b9e674'
-input-fingerprint = 'sha256:7d5135830a4ff024d865b43a69b7a2581a908cfe9fdb45cd0c98f04f65175151'
+input-fingerprint = 'sha256:b5d98ec8085872efe50914f0fe6f9c5c0f8f27c06d150b07dd01ad356d020018'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/v/vim/CVE-2026-55892.patch
+++ b/specs/v/vim/CVE-2026-55892.patch
@@ -1,0 +1,94 @@
+From bd87bdc09adba01e6124165becc8fa3cf3e7cec1 Mon Sep 17 00:00:00 2001
+From: Yasuhiro Matsumoto <mattn.jp@gmail.com>
+Date: Tue, 16 Jun 2026 20:32:21 +0000
+Subject: [PATCH] patch 9.2.0662: [security] Stack out-of-bounds write in
+ dump_prefixes()
+
+Problem:  [security]: a crafted spell file with a self-referential
+          BY_INDEX node in the prefix tree can drive dump_prefixes()
+          past the end of its MAXWLEN-sized depth arrays on :spelldump
+          (cipher-creator)
+Solution: only descend while depth < MAXWLEN - 1, as the sibling trie
+          walkers already do (Yasuhiro Matsumoto)
+
+Github Security Advisory:
+https://github.com/vim/vim/security/advisories/GHSA-qm9w-fmpj-879h
+
+Supported by AI
+
+Signed-off-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>
+Signed-off-by: Christian Brabandt <cb@256bit.org>
+
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/vim/vim/commit/8325b193bba5f01e7a7d8241f.patch
+---
+ src/spell.c                |  2 +-
+ src/testdir/test_spell.vim | 27 +++++++++++++++++++++++++++
+ src/version.c              |  2 ++
+ 3 files changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/src/spell.c b/src/spell.c
+index d06a6b8..97a6051 100644
+--- a/src/spell.c
++++ b/src/spell.c
+@@ -4326,7 +4326,7 @@ dump_prefixes(
+ 			}
+ 		    }
+ 		}
+-		else
++		else if (depth < MAXWLEN - 1)
+ 		{
+ 		    // Normal char, go one level deeper.
+ 		    prefix[depth++] = c;
+diff --git a/src/testdir/test_spell.vim b/src/testdir/test_spell.vim
+index 170ea57..2a3f0e3 100644
+--- a/src/testdir/test_spell.vim
++++ b/src/testdir/test_spell.vim
+@@ -1567,4 +1567,31 @@ let g:test_data_aff_sal = [
+       \"SAL Z                    S",
+       \ ]
+ 
++" A crafted .spl with a self-referential BY_INDEX node in the PREFIXTREE drove
++" dump_prefixes() past its MAXWLEN-sized depth arrays (stack out-of-bounds
++" write).  The tree parses cleanly (shared refs aren't recursed); the walk
++" happens on :spelldump.  Reaching the assert means no OOB.  Same class as the
++" tree_count_words() fix (9.2.0653).
++func Test_spelldump_prefixtree_overflow()
++  CheckUnix
++  call mkdir('Xrtp/spell', 'pR')
++  " VIMspell + v50, SN_PREFCOND(prefixcnt=1), SN_END,
++  " LWORDTREE word "a" with affixID=1 (so dump_prefixes runs),
++  " empty KWORDTREE, PREFIXTREE child BY_INDEX -> nodeidx 0 (self-cycle), 'A'
++  let spl = eval('0z56494D7370656C6C32030000000003000100FF00000004'
++        \ .. '0161010220010000000000000002010100000041')
++  call writefile(spl, 'Xrtp/spell/xx.utf-8.spl', 'b')
++
++  new
++  set runtimepath+=./Xrtp
++  set spelllang=xx
++  set spell
++  spelldump
++  call assert_true(line('$') > 1)
++
++  set spell& spelllang& runtimepath&
++  bwipe!
++  bwipe!
++endfunc
++
+ " vim: shiftwidth=2 sts=2 expandtab
+diff --git a/src/version.c b/src/version.c
+index 963161d..0cd4da8 100644
+--- a/src/version.c
++++ b/src/version.c
+@@ -734,6 +734,8 @@ static char *(features[]) =
+ 
+ static int included_patches[] =
+ {   /* Add new patch number below this line */
++/**/
++    662,
+ /**/
+     2146,
+ /**/
+-- 
+2.45.4
+

--- a/specs/v/vim/vim.spec
+++ b/specs/v/vim/vim.spec
@@ -60,7 +60,7 @@ Summary: The VIM editor
 URL:     https://www.vim.org/
 Name: vim
 Version: %{baseversion}.%{patchlevel}
-Release: 4%{?dist}
+Release: 5%{?dist}
 Epoch: 2
 # swift.vim contains Apache 2.0 with runtime library exception:
 # which is taken as Apache-2.0 WITH Swift-exception - reported to legal as https://gitlab.com/fedora/legal/fedora-license-data/-/issues/188
@@ -196,6 +196,7 @@ BuildRequires: libselinux-devel
 %endif
 
 
+Patch10001: CVE-2026-55892.patch
 %description
 VIM (VIsual editor iMproved) is an updated and improved version of the
 vi editor.  Vi was the first real screen-based editor for UNIX, and is
@@ -425,6 +426,7 @@ perl -pi -e "s,bin/nawk,bin/awk,g" runtime/tools/mve.awk
 %endif
 
 
+%patch -P10001 -p1
 %build
 cd src
 autoconf
@@ -1025,6 +1027,9 @@ install -p -m644 %{SOURCE11} %{buildroot}/%{_datadir}/fish/vendor_conf.d/vim-def
 
 
 %changelog
+* Sat Jul 04 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2:9.1.2146-5
+- Patch for CVE-2026-55892
+
 * Mon Feb 16 2026 Zdenek Dohnal <zdohnal@redhat.com> - 2:9.1.2146-2
 - provide previous vi->vim alias (fedora#2439657)
 


### PR DESCRIPTION
Automated CVE remediation for **vim** on Azure Linux 4.0.

Pipeline: `patch`

Autosec v1 Pipeline Run -> https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1153191

| CVE | Severity | Score | Fix |
| --- | --- | --- | --- |
| CVE-2026-55892 | Medium | 5.5 | patch-add |

_Generated by autosec-v1._